### PR TITLE
Reference env vars in "Installing" section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ We aim to follow [GDS service standards](https://www.gov.uk/service-manual/servi
     $ make debug_db
     $ make debug_migrate
     $ make debug_createsuperuser
+    
+Also make sure to set up the required environment variables for [Image storage](#image-storage).
 
 ### Running the webserver
     $ source .venv/bin/activate


### PR DESCRIPTION
This is pretty minor – I was wondering why I was getting errors from missing environment variables, and realised later that these were documented further down in the README. So let's add a link!